### PR TITLE
Change pbxproj files to relative path and macosx SDKROOT

### DIFF
--- a/MobileTerminal/adv_cmds-163/adv_cmds-163.xcodeproj/project.pbxproj
+++ b/MobileTerminal/adv_cmds-163/adv_cmds-163.xcodeproj/project.pbxproj
@@ -197,8 +197,8 @@
 			buildConfigurationList = B052630B1CA507AC00877C1C /* Build configuration list for PBXLegacyTarget "adv_cmds-163" */;
 			buildPhases = (
 			);
-			buildToolPath = /usr/bin/make;
-			buildWorkingDirectory = "/Users/steven/Dropbox/Projects/iOS/MobileTerminal/MobileTerminal/adv_cmds-163";
+			buildToolPath = make;
+			buildWorkingDirectory = "./";
 			dependencies = (
 			);
 			name = "adv_cmds-163";
@@ -351,7 +351,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -362,7 +362,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/MobileTerminal/file_cmds-251/file_cmds-251.xcodeproj/project.pbxproj
+++ b/MobileTerminal/file_cmds-251/file_cmds-251.xcodeproj/project.pbxproj
@@ -315,8 +315,8 @@
 			buildConfigurationList = B045EE301CA4DDC500CEA3B0 /* Build configuration list for PBXLegacyTarget "file_cmds-251" */;
 			buildPhases = (
 			);
-			buildToolPath = /usr/bin/make;
-			buildWorkingDirectory = "/Users/steven/Dropbox/Projects/iOS/MobileTerminal/MobileTerminal/file_cmds-251";
+			buildToolPath = make;
+			buildWorkingDirectory = "./";
 			dependencies = (
 			);
 			name = "file_cmds-251";
@@ -546,7 +546,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -557,7 +557,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/MobileTerminal/network_cmds-481.20.1/network_cmds-481.20.1.xcodeproj/project.pbxproj
+++ b/MobileTerminal/network_cmds-481.20.1/network_cmds-481.20.1.xcodeproj/project.pbxproj
@@ -327,8 +327,8 @@
 			buildConfigurationList = B0AB90121CA580F4001649D2 /* Build configuration list for PBXLegacyTarget "network_cmds-481.20.1" */;
 			buildPhases = (
 			);
-			buildToolPath = /usr/bin/make;
-			buildWorkingDirectory = "/Users/steven/Dropbox/Projects/iOS/MobileTerminal/MobileTerminal/network_cmds-481.20.1";
+			buildToolPath = make;
+			buildWorkingDirectory = "./";
 			dependencies = (
 			);
 			name = "network_cmds-481.20.1";
@@ -572,7 +572,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -583,7 +583,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};

--- a/MobileTerminal/text_cmds-88/text_cmds-88.xcodeproj/project.pbxproj
+++ b/MobileTerminal/text_cmds-88/text_cmds-88.xcodeproj/project.pbxproj
@@ -373,8 +373,8 @@
 			buildConfigurationList = B05263A61CA50CFE00877C1C /* Build configuration list for PBXLegacyTarget "text_cmds-88" */;
 			buildPhases = (
 			);
-			buildToolPath = /usr/bin/make;
-			buildWorkingDirectory = "/Users/steven/Dropbox/Projects/iOS/MobileTerminal/MobileTerminal/text_cmds-88";
+			buildToolPath = make;
+			buildWorkingDirectory = "./";
 			dependencies = (
 			);
 			name = "text_cmds-88";
@@ -653,7 +653,7 @@
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				ONLY_ACTIVE_ARCH = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Debug;
 		};
@@ -664,7 +664,7 @@
 				COPY_PHASE_STRIP = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				SDKROOT = macosx10.6;
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
It wouldn't compile without these changes for me.

Also wouldn't compile without changing:
```diff
-typedef enum {
+typedef enum colorCode {
     COLORCODE_BLACK=0,
     COLORCODE_RED=1,
     COLORCODE_GREEN=2,
 @@ -175,7 +175,6 @@ typedef enum {
     COLORCODE_WATER=6,
     COLORCODE_WHITE=7,
     COLORCODE_256=8,
-    COLORS
 } colorCode;
```
in `MobileTerminal/VT100Terminal.h` but I don't know whether that's even remotely correct so I left that out.

Once it compiled and run I got
> 2017-02-02 21:01:28.453 MobileTerminal[0:124231] AX Error: unable to find own process' entitlements: No such process

Can't say I understand much of this, so I'm probably going to give up here 😅